### PR TITLE
Low Spec Terrain Shader Fix

### DIFF
--- a/LotRRealmsInExileDev/gfx/FX/pdxterrain.shader
+++ b/LotRRealmsInExileDev/gfx/FX/pdxterrain.shader
@@ -663,7 +663,7 @@ PixelShader =
 					//FinalColor = ApplyFogOfWar( FinalColor, Input.WorldSpacePos, FogOfWarAlpha );
 					FinalColor = GH_ApplyAtmosphericEffects( FinalColor, Input.WorldSpacePos, FogOfWarAlpha );
 					// END MOD
-					FinalColor = ApplyMapDistanceFog( FinalColor, Input.WorldSpacePos );
+					FinalColor = ApplyMapDistanceFog( FinalColor, Input.WorldSpacePos, FogOfWarAlpha );
 				#endif
 
 				#ifdef TERRAIN_COLOR_OVERLAY


### PR DESCRIPTION
This adds a missing argument to `ApplyMapDistanceFog()` in `PixelShaderLowSpec`, solving the shader compile error which was causing a crash when loading onto the map with the "Advanced Shader Effects" checkbox turned off.