### PR TITLE
Vanilla Terrain Normals Bug Fix

### DIFF
--- a/LotRRealmsInExileDev/gfx/FX/pdxterrain.shader
+++ b/LotRRealmsInExileDev/gfx/FX/pdxterrain.shader
@@ -526,7 +526,10 @@ PixelShader =
 						// Use the property that only water has lower roughness to adjust the terrain normals to face upward.
 						float WaterNormalAdjustment = smoothstep( 0.6f, 1.0f, 1 - DetailMaterial.a);
 						WaterNormalLerp = max( WaterNormalLerp, WaterNormalAdjustment);
-						float3 ReorientedNormal = ReorientNormal(
+						// MOD(lotr)
+						//float3 ReorientedNormal = ReorientNormal(
+						ReorientedNormal = ReorientNormal( // vanilla bug: unintentional shadowing of ReorientedNormal from the outer scope
+						// END MOD
 							lerp( Normal, float3( 0.0f, 1.0f, 0.0f ), WaterNormalLerp ),
 							DetailNormal );
 


### PR DESCRIPTION
This fixes a vanilla shader bug from v1.18.2 which caused terrain normals to disappear.

<img width="1600" height="900" alt="image" src="https://github.com/user-attachments/assets/a7750910-c0d9-481c-87cf-4b0cec9d898e" />
